### PR TITLE
Fix string to numeric value conversion in PHP 7.1

### DIFF
--- a/class.plugin-boilerplate.php
+++ b/class.plugin-boilerplate.php
@@ -47,7 +47,7 @@ if ( !class_exists( 'Plugin_Boilerplate_v_2' ) ):
 	function __construct( &$child ) {
 
 		//don't let this fire twice
-		if ( get_class( $this ) == 'Plugin_Boilerplate_v_' + $this->version )
+		if ( get_class( $this ) == 'Plugin_Boilerplate_v_' . $this->version )
 			return;
 
 		//verify minimum WP version, and shutdown if insufficient


### PR DESCRIPTION
Fix following PHP warnings and notices in PHP 7.1
- A non-numeric value encountered
- A non well formed numeric value encountered

The reason to fix this is that the boilerplate is being used in the following plugin: https://github.com/benbalter/Twitter-Mentions-as-Comments